### PR TITLE
Added method to clear only last fragment

### DIFF
--- a/library/src/com/mapsaurus/paneslayout/ActivityDelegate.java
+++ b/library/src/com/mapsaurus/paneslayout/ActivityDelegate.java
@@ -50,6 +50,11 @@ public abstract class ActivityDelegate {
 	 * Clear all fragments from stack
 	 */
 	public abstract void clearFragments();
+	
+	/**
+	 * Clear only last fragment from stack
+	 */
+	public abstract void clearLastFragment();
 
 	/**
 	 * Get menu framgent

--- a/library/src/com/mapsaurus/paneslayout/PanesActivity.java
+++ b/library/src/com/mapsaurus/paneslayout/PanesActivity.java
@@ -108,6 +108,13 @@ public abstract class PanesActivity extends SherlockFragmentActivity implements 
 	public void clearFragments() {
 		mDelegate.clearFragments();
 	}
+	
+	/**
+	 * Clear last fragment from stack
+	 */
+	public void clearLastFragment() {
+		mDelegate.clearLastFragment();
+	}
 
 	/**
 	 * Get menu framgent

--- a/library/src/com/mapsaurus/paneslayout/PhoneDelegate.java
+++ b/library/src/com/mapsaurus/paneslayout/PhoneDelegate.java
@@ -30,7 +30,7 @@ SlidingMenu.OnOpenListener, SlidingMenu.OnCloseListener, OnBackStackChangedListe
 	public void onSaveInstanceState(Bundle savedInstanceState) {
 		savedInstanceState.putBoolean("PhoneLayout_menuOpen", menu.isMenuShowing());
 	}
-	
+
 	@Override
 	public void onDestroy() {
 	}
@@ -132,7 +132,7 @@ SlidingMenu.OnOpenListener, SlidingMenu.OnCloseListener, OnBackStackChangedListe
 	 * we need to retrieve a fragment, that fragment has not yet been added.
 	 */
 	private WeakReference<Fragment> wMenuFragment = new WeakReference<Fragment>(null);
-	
+
 	@Override
 	public void addFragment(Fragment prevFragment, Fragment newFragment) {
 		boolean addToBackStack = false;
@@ -165,12 +165,19 @@ SlidingMenu.OnOpenListener, SlidingMenu.OnCloseListener, OnBackStackChangedListe
 	}
 
 	@Override
+	public void clearLastFragment() {
+		FragmentManager fm = getSupportFragmentManager();
+		if (fm.getBackStackEntryCount() > 0)       
+			fm.popBackStack();
+	}	
+
+	@Override
 	public void setMenuFragment(Fragment f) {
 		FragmentManager fm = getSupportFragmentManager();
 		FragmentTransaction ft = fm.beginTransaction();
 		ft.replace(R.id.menu_frame, f);
 		ft.commit();
-		
+
 		wMenuFragment = new WeakReference<Fragment>(f);
 
 		updateFragment(f);

--- a/library/src/com/mapsaurus/paneslayout/TabletDelegate.java
+++ b/library/src/com/mapsaurus/paneslayout/TabletDelegate.java
@@ -206,6 +206,11 @@ public class TabletDelegate extends ActivityDelegate implements PanesLayout.OnIn
 	public void clearFragments() {
 		clearFragments(0);
 	}
+	
+	@Override
+	public void clearLastFragment() {
+		clearFragments(panesLayout.getCurrentIndex());
+	}
 
 	@Override
 	public void setMenuFragment(Fragment menuFragment) {


### PR DESCRIPTION
...as opposed to clearing all the fragments at once.

Sometimes there is a need to go only one step up in the hierarchy. I added a method which clears only last fragment which is on top of the stack, all other fragments remain in place.
