### PR TITLE
Added method to clear only last fragment

### DIFF
--- a/library/src/com/mapsaurus/paneslayout/ActivityDelegate.java
+++ b/library/src/com/mapsaurus/paneslayout/ActivityDelegate.java
@@ -54,6 +54,11 @@ public abstract class ActivityDelegate {
 	 * Clear all fragments from stack
 	 */
 	public abstract void clearFragments();
+	
+    /**
+     * Clear only last fragment from stack
+     */
+    public abstract void clearLastFragment();
 
 	/**
 	 * Get menu framgent

--- a/library/src/com/mapsaurus/paneslayout/PanesActivity.java
+++ b/library/src/com/mapsaurus/paneslayout/PanesActivity.java
@@ -119,6 +119,13 @@ public abstract class PanesActivity extends SherlockFragmentActivity implements 
 	public void clearFragments() {
 		mDelegate.clearFragments();
 	}
+	
+    /**
+     * Clear last fragment from stack
+     */
+    public void clearLastFragment() {
+        mDelegate.clearLastFragment();
+    }
 
 	/**
 	 * Get menu framgent

--- a/library/src/com/mapsaurus/paneslayout/PhoneDelegate.java
+++ b/library/src/com/mapsaurus/paneslayout/PhoneDelegate.java
@@ -161,6 +161,13 @@ public class PhoneDelegate extends ActivityDelegate implements OnBackStackChange
 		for(int i = 0; i < fm.getBackStackEntryCount(); i ++)    
 			fm.popBackStack();
 	}
+	
+    @Override
+    public void clearLastFragment() {
+        FragmentManager fm = getSupportFragmentManager();
+        if (fm.getBackStackEntryCount() > 0)       
+            fm.popBackStack();
+    }    
 
 	@Override
 	public void setMenuFragment(Fragment f) {

--- a/library/src/com/mapsaurus/paneslayout/TabletDelegate.java
+++ b/library/src/com/mapsaurus/paneslayout/TabletDelegate.java
@@ -203,6 +203,11 @@ public class TabletDelegate extends ActivityDelegate implements PanesLayout.OnIn
 	public void clearFragments() {
 		clearFragments(0);
 	}
+	
+    @Override
+    public void clearLastFragment() {
+        clearFragments(panesLayout.getCurrentIndex());
+    }
 
 	@Override
 	public void setMenuFragment(Fragment menuFragment) {


### PR DESCRIPTION
...as opposed to clearing all the fragments at once.

Sometimes there is a need to go only one step up in the hierarchy. I added a method which clears only last fragment which is on top of the stack, all other fragments remain in place.
